### PR TITLE
add documentation for library reporter options

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -263,6 +263,7 @@ newman.run({
             value: "Global Bar",
         }
     ],
+    reporters: ['html', 'junit', 'json'],
     reporter: {
         html: {
             export: 'htmlOutput.html'

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ return of the `newman.run` function is a run instance, which emits run events th
 | options.bail              | A boolean switch to specify whether or not to gracefully stop a collection run on encountering the first error. Takes no arguments.<br /><br />_Optional_<br />Type: `boolean`, Default value: `false` |
 | options.suppressExitCode  | If present, allows overriding the default exit code from the current collection run, useful for bypassing collection result failures. Takes no arguments.<br /><br />_Optional_<br />Type: `boolean`, Default value: `false` |
 | options.reporters         | Specify one reporter name as `string` or provide more than one reporter name as an `array`.<br /><br />Available reporters: `cli`, `html` and `junit`.<br /><br />_Optional_<br />Type: `string|array` |
+| options.reporter          | Specify options for the reporter(s) declared in `options.reporters`. <br /> e.g. `reporter : { junit : { export : './xmlResults.xml' } }` <br /><br />_Optional_<br />Type: `object` |
 | options.noColor           | Newman attempts to automatically turn off color output to terminals when it detects the lack of color support. With this property, one can forcibly turn off the usage of color in terminal output for reporters and other parts of Newman that output to console.<br /><br />_Optional_<br />Type: `boolean` |
 | callback                  | Upon completion of the run, this callback is executed with the `error`, `summary` argument.<br /><br />_Required_<br />Type: `function` |
 


### PR DESCRIPTION
Not sure if this is changing in final version, but configuring the reporters was when using as a lib was a little unclear to me
